### PR TITLE
lib now waits for report to be sent to DMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ async function foo(someId) {
 const wrapped = dms.wrap('76d84d19e4', foo);
 
 const result = await wrapped('some-input');
+
+// wrap an existing promise-returning function with a blocking call to DMS and report the outcome
+const wrapped = dms.wrapBlocking('76d84d19e4', foo);
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple library for reporting to [Dead Man's Snitch](https://deadmanssnitch.com).
 
-Returns promises only. Standard callbacks are not supported.
+Returns promises only. Standard callbacks are not supported. Though optionally you can just "fire and forget" and discard the returned promise - in this case, delivery isn't guaranteed, but is still likely.
 
 You can either report manually, or wrap an existing promise-returning function.
 
@@ -21,17 +21,16 @@ await dms.report('76d84d19e4', { s: 1, m: 'foobar error occurred' });
 // wrap an existing promise-returning function and report the outcome
 // - promise resolved -> success with no message
 // - promise rejected -> failure with `error.message` as the message
-async function foo(someId) {
+async foo(someId) {
 	return await doSomething(someId);
 }
 
 // if doing e.g. `obj.foo`, you may need to do `obj.foo.bind(obj)`
 const wrapped = dms.wrap('76d84d19e4', foo);
 
-const result = await wrapped('some-input');
+const wrappedBlocking = dms.wrapBlocking('76d84d19e4', foo);
 
-// wrap an existing promise-returning function with a blocking call to DMS and report the outcome
-const wrapped = dms.wrapBlocking('76d84d19e4', foo);
+const result = await wrapped('some-input');
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple library for reporting to [Dead Man's Snitch](https://deadmanssnitch.com).
 
-Returns promises only. Standard callbacks are not supported. Though optionally you can just "fire and forget" and discard the returned promise - in this case, delivery isn't guaranteed, but is still likely.
+Returns promises only. Standard callbacks are not supported.
 
 You can either report manually, or wrap an existing promise-returning function.
 
@@ -21,7 +21,7 @@ await dms.report('76d84d19e4', { s: 1, m: 'foobar error occurred' });
 // wrap an existing promise-returning function and report the outcome
 // - promise resolved -> success with no message
 // - promise rejected -> failure with `error.message` as the message
-async foo(someId) {
+async function foo(someId) {
 	return await doSomething(someId);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,21 +20,23 @@ function report(token, params = {}) {
 }
 
 function wrap(token, func) {
-	return function () {
-		return func.apply(null, arguments).then(
-			function (result) {
-				report(token);
-
-				return result;
-			},
-			function (error) {
-				report(token, {
-					s: 1,
-					m: error.message,
-				});
-
-				throw error;
-			},
-		);
+	return async () => {
+		try {
+			const result = await func.apply(null, arguments)
+			await tryReport(token)
+			return result;
+		} catch (error) {
+			await tryReport(token, {s: 1, m: error.message})
+			throw error;
+		}
 	};
+}
+
+async function tryReport(token, params) {
+	try {
+		if (params)
+			await report(token, params);
+		else
+			await report(token);
+	} catch {} // Ignoring failed reports
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const fetch = require('fetch-everywhere');
 
 exports.report = report;
 exports.wrap = wrap;
+exports.wrapBlocking = wrapBlocking;
 
 function report(token, params = {}) {
 	const body = Object.keys(params)
@@ -20,23 +21,40 @@ function report(token, params = {}) {
 }
 
 function wrap(token, func) {
+	return function () {
+		return func.apply(null, arguments).then(
+			function (result) {
+				report(token);
+
+				return result;
+			},
+			function (error) {
+				report(token, {
+					s: 1,
+					m: error.message,
+				});
+
+				throw error;
+			},
+		);
+	};
+}
+
+function wrapBlocking(token, func) {
 	return async () => {
 		try {
-			const result = await func.apply(null, arguments)
-			await tryReport(token)
+			const result = await func.apply(null, arguments);
+			await tryReport(token);
 			return result;
 		} catch (error) {
-			await tryReport(token, {s: 1, m: error.message})
+			await tryReport(token, {s: 1, m: error.message});
 			throw error;
 		}
 	};
 }
 
-async function tryReport(token, params) {
+async function tryReport(token, params = {}) {
 	try {
-		if (params)
-			await report(token, params);
-		else
-			await report(token);
+		await report(token, params);
 	} catch {} // Ignoring failed reports
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,17 +44,13 @@ function wrapBlocking(token, func) {
 	return async () => {
 		try {
 			const result = await func.apply(null, arguments);
-			await tryReport(token);
+			await report(token);
+
 			return result;
 		} catch (error) {
-			await tryReport(token, {s: 1, m: error.message});
+			await report(token, {s: 1, m: error.message});
+
 			throw error;
 		}
 	};
-}
-
-async function tryReport(token, params = {}) {
-	try {
-		await report(token, params);
-	} catch {} // Ignoring failed reports
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dms-report",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Simple library for reporting to Dead Man's Snitch (deadmanssnitch.com)",
   "homepage": "https://github.com/billinghamj/dms-report",
   "bugs": "https://github.com/billinghamj/dms-report/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dms-report",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "Simple library for reporting to Dead Man's Snitch (deadmanssnitch.com)",
   "homepage": "https://github.com/billinghamj/dms-report",
   "bugs": "https://github.com/billinghamj/dms-report/issues",


### PR DESCRIPTION
Due to AWS Lambda terminating before the request is successfully sent to DMS, the code has been changed slightly to wait for the report to complete. Failed task executions pass on exceptions to DMS, and failed DMS requests will not throw any exceptions.